### PR TITLE
Modify markdown components stylings

### DIFF
--- a/src/components/molecules/Header.tsx
+++ b/src/components/molecules/Header.tsx
@@ -12,9 +12,10 @@ const Header: FC = () => {
       alignItems="center"
       maxWidth="900px"
       width="100%"
-      p={8}
-      mt={[0, 8]}
-      mb={8}
+      px={8}
+      py={[4, 4, 8]}
+      mt={[0, 0, 8]}
+      mb={[0, 0, 8]}
       mx="auto"
     >
       <Box>

--- a/src/components/molecules/MDXComponents.tsx
+++ b/src/components/molecules/MDXComponents.tsx
@@ -152,8 +152,11 @@ const Hr = () => {
 
 const MDXComponents = {
   h1: (props) => <Heading as="h1" size="xl" my={4} {...props} />,
-  h2: (props) => <DocsHeading as="h2" fontWeight="bold" size="lg" {...props} />,
+  h2: (props) => <DocsHeading as="h2" size="lg" fontWeight="bold" {...props} />,
   h3: (props) => <DocsHeading as="h3" size="md" fontWeight="bold" {...props} />,
+  h4: (props) => <DocsHeading as="h4" size="sm" fontWeight="bold" {...props} />,
+  h5: (props) => <DocsHeading as="h5" size="xs" fontWeight="bold" {...props} />,
+  h6: (props) => <DocsHeading as="h6" size="xs" fontWeight="bold" {...props} />,
   inlineCode: (props) => (
     <Code colorScheme="yellow" fontSize="0.84em" {...props} />
   ),

--- a/src/components/molecules/MDXComponents.tsx
+++ b/src/components/molecules/MDXComponents.tsx
@@ -103,18 +103,18 @@ const DocsHeading = (props) => {
         '&[id]': {
           pointerEvents: 'none',
         },
-        '&[id]:before': {
-          display: 'block',
-          height: ' 6rem',
-          marginTop: '-6rem',
-          visibility: 'hidden',
-          content: '""',
-        },
+        // '&[id]:before': {
+        //   display: 'block',
+        //   height: ' 6rem',
+        //   marginTop: '-6rem',
+        //   visibility: 'hidden',
+        //   content: '""',
+        // },
         '&[id]:hover a': { opacity: 1 },
       }}
       {...props}
-      mb="1em"
-      mt="2em"
+      mb={['0.5em', '0.5em', '1em']}
+      mt={['1em', '1em', '2em']}
     >
       <Box pointerEvents="auto">
         {children}

--- a/src/utility/prismTheme.ts
+++ b/src/utility/prismTheme.ts
@@ -5,8 +5,8 @@ const prismBaseTheme = css`
   code {
     white-space: pre;
   }
-  code[class*='language-'],
-  pre[class*='language-'] {
+  code:not(.chakra-code),
+  pre:not(.chakra-code) {
     color: ${theme.colors.gray[800]};
     background: none;
     font-family: ${theme.fonts.mono};
@@ -26,7 +26,7 @@ const prismBaseTheme = css`
     width: 100%;
   }
   /* Code blocks */
-  pre[class*='language-'] {
+  pre:not(.chakra-code) {
     padding-top: ${theme.space[4]};
     padding-bottom: ${theme.space[4]};
     padding-left: ${theme.space[4]};
@@ -37,14 +37,14 @@ const prismBaseTheme = css`
     font-size: 0.9rem;
     white-space: nowrap;
   }
-  :not(pre) > code[class*='language-'],
-  pre[class*='language-'] {
+  :not(pre) > code:not(.chakra-code),
+  pre:not(.chakra-code) {
     background: ${theme.colors.gray[50]};
     border: 1px solid ${theme.colors.gray[200]};
     border-radius: ${theme.radii.lg};
   }
   /* Inline code */
-  :not(pre) > code[class*='language-'] {
+  :not(pre) > code:not(.chakra-code) {
     padding: 0.1em;
     border-radius: 0.3em;
     white-space: normal;
@@ -141,12 +141,12 @@ const prismBaseTheme = css`
 
 export const prismLightTheme = css`
   ${prismBaseTheme};
-  code[class*='language-'],
-  pre[class*='language-'] {
+  code:not(.chakra-code),
+  pre:not(.chakra-code) {
     color: ${theme.colors.gray[800]};
   }
-  :not(pre) > code[class*='language-'],
-  pre[class*='language-'] {
+  :not(pre) > code:not(.chakra-code),
+  pre:not(.chakra-code) {
     background: ${theme.colors.gray[50]};
     border: 1px solid ${theme.colors.gray[200]};
   }
@@ -157,7 +157,7 @@ export const prismLightTheme = css`
 
 export const prismDarkTheme = css`
   ${prismBaseTheme};
-  :not(pre) > code[class*='language-'] {
+  :not(pre) > code:not(.chakra-code) {
     background: #011627;
   }
   .token.attr-name {
@@ -208,12 +208,14 @@ export const prismDarkTheme = css`
   .token.namespace {
     color: rgb(178, 204, 214);
   }
-  code[class*='language-'],
-  pre[class*='language-'] {
+
+  code:not(.chakra-code),
+  pre:not(.chakra-code) {
     color: ${theme.colors.gray[50]};
   }
-  :not(pre) > code[class*='language-'],
-  pre[class*='language-'] {
+
+  :not(pre) > code:not(.chakra-code),
+  pre:not(.chakra-code) {
     background: ${theme.colors.gray[800]};
     border: 1px solid ${theme.colors.gray[700]};
   }


### PR DESCRIPTION
- Responsive margin/padding
- Add `h4` `h5` `h6` settings to `MDXComponents`
- Apply code highlight to non-file code-block

![スクリーンショット 2020-10-18 17 49 23](https://user-images.githubusercontent.com/32263803/96365371-49f60e80-116a-11eb-9e7d-5cfbf806709c.png)
